### PR TITLE
Added condition to convert image to rgb only when it is rgb

### DIFF
--- a/imquality/brisque.py
+++ b/imquality/brisque.py
@@ -42,7 +42,10 @@ class Brisque:
         sigma: float = 7 / 6,
     ):
         self.image = pil2ndarray(image)
-        self.image = skimage.color.rgb2gray(self.image)
+
+        if self.image.shape[-1] == 3:
+            self.image = skimage.color.rgb2gray(self.image)
+
         self.kernel_size = kernel_size
         self.sigma = sigma
         self.kernel = gaussian_kernel2d(kernel_size, sigma)


### PR DESCRIPTION
When running `brisque.score()`, and error gets thrown:

> ValueError: the input array must have size 3 along channel_axis, got (80, 512)

The problem is that in the `calculate_features` function in `brisque.py`, two `Brisque` objects get created.

Within the constructor of the `Brique` class, the function `skimage.color.rgb2gray()` gets called.

Back to the `calculate_features` method, the first `Brique` object that gets called, the input image is RGB; however, the second `Brique` object that gets called is already in grayscale. The `skimage.color.rgb2gray()` function throws an error that the input is already in grayscale as it expects 3 channels.

The solution was to add a condition around the call to `skimage.color.rgb2gray()` within the `Brisque` class.

Replace line 45 of `imquality/brisque.py' with:

```
# Only convert image to grayscale if RGB
if self.image.shape[-1] == 3:
    self.image = skimage.color.rgb2gray(self.image)
```