### PR TITLE
BUG FIXES in imquality/brisque.py

### DIFF
--- a/imquality/brisque.py
+++ b/imquality/brisque.py
@@ -42,10 +42,8 @@ class Brisque:
         sigma: float = 7 / 6,
     ):
         self.image = pil2ndarray(image)
-
         if self.image.shape[-1] == 3:
             self.image = skimage.color.rgb2gray(self.image)
-
         self.kernel_size = kernel_size
         self.sigma = sigma
         self.kernel = gaussian_kernel2d(kernel_size, sigma)
@@ -142,7 +140,7 @@ def calculate_features(image: PIL.Image, kernel_size, sigma) -> numpy.ndarray:
             order=2,
             mode="constant",
             anti_aliasing=False,
-            multichannel=False,
+            channel_axis=None,
         )
     downscaled_brisque = Brisque(downscaled_image, kernel_size=kernel_size, sigma=sigma)
     features = numpy.concatenate([brisque.features, downscaled_brisque.features])


### PR DESCRIPTION
imquality/brisque.py:
 1) line 45: condition added to avoid grayscale image being converted again, resulting in an error: ValueError: the input array must have size 3 along channel_axis, got (250, 358)
 2) line 143: the argument name in a new version os skimage.transform.rescale() was changed in the lates version from multichannel=False -> channel_axis=None, which was producing an error: TypeError: rescale() got an unexpected keyword argument 'multichannel'
 3) Also, in the requirements the version of the version should be set to scipy==1.11.4 as in the there is an error in the site-packages/libsvm/svm.py AttributeError: Module 'scipy' has no attribute 'ndarray' in the newer scipy==1.13.1